### PR TITLE
Adding new udev rule device id.

### DIFF
--- a/src/40-rocketlauncher.rules
+++ b/src/40-rocketlauncher.rules
@@ -1,3 +1,4 @@
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1941", ATTRS{idProduct}=="8021", GROUP="plugdev", MODE="0660"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0a81", ATTRS{idProduct}=="0701", GROUP="plugdev", MODE="0660"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1130", ATTRS{idProduct}=="0202", GROUP="plugdev", MODE="0660"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="2123", ATTRS{idProduct}=="1010", GROUP="plugdev", MODE="0660"


### PR DESCRIPTION
Adding additional udev rule for idVendor 2123 and idProduct 1010.
Tested on Ubuntu 12.04 with no issues.
